### PR TITLE
Set branch and update README

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "cdap"]
 	path = cdap
 	url = git@github.com:caskdata/cdap.git
+	branch = release/3.2

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
 # CDAP Build repository
 
 This repository is used solely for building a complete CDAP release.
-
-- Checks out CDAP and external repositories
-  - cask-tracker
-  - cdap-navigator
-  - cdap-security-extn
-  - hydrator-plugins
-- Builds all modules


### PR DESCRIPTION
This sets the branch for newer git, which can be tracked by using `git submodule update --remote` to update the working directory to the remote branch's HEAD. Also, removes documentation about other modules from the README, since they're not used on this branch.