### PR TITLE
Switch to using HTTPS for public repositories

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "cdap"]
 	path = cdap
-	url = git@github.com:caskdata/cdap.git
+	url = https://github.com/caskdata/cdap.git
 	branch = release/3.5
 [submodule "app-artifacts/hydrator-plugins"]
 	path = app-artifacts/hydrator-plugins
-	url = git@github.com:caskdata/hydrator-plugins.git
+	url = https://github.com/caskdata/hydrator-plugins.git
 	branch = release/1.4
 [submodule "app-artifacts/cask-tracker"]
 	path = app-artifacts/cask-tracker
-	url = git@github.com:caskdata/cask-tracker.git
+	url = https://github.com/caskdata/cask-tracker.git
 	branch = release/0.2
 [submodule "app-artifacts/cdap-navigator"]
 	path = app-artifacts/cdap-navigator
-	url = git@github.com:caskdata/cdap-navigator.git
+	url = https://github.com/caskdata/cdap-navigator.git
 	branch = release/0.2
 [submodule "security-extensions/cdap-security-extn"]
 	path = security-extensions/cdap-security-extn
-	url = git@github.com:caskdata/cdap-security-extn.git
+	url = https://github.com/caskdata/cdap-security-extn.git
 	branch = release/0.2
 [submodule "apache-sentry"]
 	path = apache-sentry
-	url = git@github.com:apache/sentry.git
+	url = https://github.com/apache/sentry.git
 	branch = branch-1.7.0


### PR DESCRIPTION
Unfortunately, we were abusing a Bamboo problem with our original configuration. This allows us to checkout our repositories without dealing with Bamboo's interesting handling of SSH credentials for repositories.

Build: http://builds.cask.co/browse/CDAP-CTNB8-1
Fixes: http://builds.cask.co/admin/viewError.action?buildKey=CDAP-CTNB6-RCU&error=4