### PR TITLE
Do not deploy cdap-build module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>co.cask.cdap.build</groupId>
+  <groupId>co.cask.cdap</groupId>
   <artifactId>cdap-build</artifactId>
   <version>1.0</version>
   <packaging>pom</packaging>
@@ -33,5 +33,16 @@
     <module>security-extensions/cdap-security-extn</module>
     <module>cdap</module>
   </modules>
+
+  <plugins>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-deploy-plugin</artifactId>
+      <version>2.8</version>
+      <configuration>
+        <skip>true</skip>
+      </configuration>
+    </plugin>
+  </plugins>
 
 </project>


### PR DESCRIPTION
This will prevent the `cdap-build` module from attempting to deploy to Maven Central.