### PR TITLE
Use git://git.apache.org/sentry.git for apache/sentry Git repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,5 +20,5 @@
 	branch = release/0.3
 [submodule "apache-sentry"]
 	path = apache-sentry
-	url = https://github.com/apache/sentry.git
+	url = git://git.apache.org/apache/sentry.git
 	branch = branch-1.7.0


### PR DESCRIPTION
Switch remotes to git.apache.org as GitHub appears to be blank, now.