### PR TITLE
Use git://git.apache.org/sentry.git for apache/sentry Git repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,5 +20,5 @@
 	branch = release/0.4
 [submodule "apache-sentry"]
 	path = apache-sentry
-	url = https://github.com/apache/sentry.git
+	url = git://git.apache.org/sentry.git
 	branch = branch-1.7.0


### PR DESCRIPTION
Update remote to use git.apache.org instead of GitHub mirror